### PR TITLE
trivial header fix to silence warning

### DIFF
--- a/include/lpel.h
+++ b/include/lpel.h
@@ -219,13 +219,13 @@ lpel_task_iterator_t *LpelTaskIterCreate(taskqueue_t *queue, int length);
 /*  PLACEMENT SCHEDULER FUNCTIONS                                             */
 /******************************************************************************/
 
-void LpelPlacementSchedulerInit();
+void LpelPlacementSchedulerInit(void);
 
 void LpelPlacementSchedulerWorkerIndices(int prio, int **workers, int *n);
 
 void LpelPlacementSchedulerRun(void *args);
 
-void LpelPlacementSchedulerDestroy();
+void LpelPlacementSchedulerDestroy(void);
 
 int LpelPlacementSchedulerGetWorker(int prio, int i);
 

--- a/src/placementscheduler.c
+++ b/src/placementscheduler.c
@@ -338,7 +338,7 @@ static void RandomPlacement(workerctx_t *wc)
 }
 #endif
 
-void LpelPlacementSchedulerDestroy()
+void LpelPlacementSchedulerDestroy(void)
 {
   int i;
   for(i = 0; i<SCHED_NUM_PRIO; i++) {
@@ -355,7 +355,7 @@ void LpelPlacementSchedulerDestroy()
 #endif
 }
 
-void LpelPlacementSchedulerInit()
+void LpelPlacementSchedulerInit(void)
 {
   lpel_config_t *config = &_lpel_global_config;
   int i;


### PR DESCRIPTION
It was giving warnings under strict gcc settings we use in sac2c,
