### PR TITLE
Add LpelStreamGetId

### DIFF
--- a/include/lpel.h
+++ b/include/lpel.h
@@ -241,7 +241,7 @@ void  LpelStreamWrite(    lpel_stream_desc_t *sd, void *item);
 int   LpelStreamTryWrite( lpel_stream_desc_t *sd, void *item);
 
 lpel_stream_t *LpelStreamGet(lpel_stream_desc_t *sd);
-
+int LpelStreamGetId(lpel_stream_desc_t *sd);
 
 
 /** stream set functions*/

--- a/src/stream.c
+++ b/src/stream.c
@@ -591,4 +591,10 @@ lpel_stream_desc_t *LpelStreamPoll( lpel_streamset_t *set)
   return self->wakeup_sd;
 }
 
+int LpelStreamGetId(lpel_stream_desc_t *sd) {
+	if (sd)
+		if (sd->stream)
+			return sd->stream->uid;
+	return -1;
+}
 


### PR DESCRIPTION
This is used for debugging only. This should be added to be consistent with snet-rts.
