### PR TITLE
fix for the case when PCL is installed into a lib64 subdirectory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,8 @@ if test "x$with_pcl" != xcheck; then
     dnl library
     if test -r "$with_pcl/lib/libpcl.la"; then
       LIBPCL_LA=$with_pcl/lib/libpcl.la
+    elif test -r "$with_pcl/lib64/libpcl.la"; then
+      LIBPCL_LA=$with_pcl/lib64/libpcl.la
     elif test -r "$with_pcl/pcl/libpcl.la"; then
       LIBPCL_LA=$with_pcl/pcl/libpcl.la
     else


### PR DESCRIPTION
This patch to configure.ac fixes the case when the PCL libraries
are installed into a lib64 subdirectory of the PCL prefix.
