### PR TITLE
new lock in stream and bug fixing

### DIFF
--- a/src/buffer/bounded.c
+++ b/src/buffer/bounded.c
@@ -32,7 +32,6 @@ struct buffer_t {
 //  volatile unsigned long pwrite;
   long padding2[longxCacheLine-1];
   unsigned long size;
-  int count;
   void **data;
 };
 
@@ -49,7 +48,6 @@ buffer_t *LpelBufferInit(unsigned int size)
   buf->pread = 0;
   buf->pwrite = 0;
   buf->size = size;
-  buf->count = 0;
   buf->data = malloc( size*sizeof(void*) );
   /* clear all the buffer space */
   memset(buf->data, 0, size*sizeof(void *));
@@ -97,7 +95,6 @@ void LpelBufferPop( buffer_t *buf)
   /* clear, and advance pread */
   buf->data[buf->pread]=NULL;
   buf->pread += (buf->pread+1 >= buf->size) ? (1-buf->size) : 1;
-  buf->count--;
 }
 
 
@@ -145,19 +142,8 @@ void LpelBufferPut( buffer_t *buf, void *item)
   WMB();
   buf->data[buf->pwrite] = item;
   buf->pwrite += (buf->pwrite+1 >= buf->size) ? (1-buf->size) : 1;
-  buf->count++;
 }
 
 
-
-/**
- * Return the number of data item in the buffer
- *
- * @param buf   buffer
- * @pre         no concurrent calls
- */
-int	LpelBufferCount(buffer_t *buf) {
-	return buf->count;
-}
 
 

--- a/src/buffer/unbounded_ll.c
+++ b/src/buffer/unbounded_ll.c
@@ -21,7 +21,6 @@ struct entry {
 struct buffer_t{
 	entry *head;
 	entry *tail;
-	int count;
 };
 
 static entry *createEntry(void *data) {
@@ -43,7 +42,6 @@ buffer_t *LpelBufferInit(unsigned int size)
 	buffer_t *buf = (buffer_t *) malloc(sizeof(buffer_t));
   buf->head = createEntry(NULL);
   buf->tail = buf->head;
-  buf->count = 0;
   return buf;
 }
 
@@ -90,7 +88,6 @@ void LpelBufferPop( buffer_t *buf)
 	    return;
 	  entry *t = buf->head;
 	  buf->head = t->next;
-	  buf->count--;
 	  free(t);
 }
 
@@ -136,16 +133,6 @@ void LpelBufferPut( buffer_t *buf, void *item)
   WMB();
   buf->tail->next = createEntry(item);
   buf->tail = buf->tail->next;
-  buf->count++;
 }
 
 
-/**
- * Return the number of data item in the buffer
- *
- * @param buf   buffer
- * @pre         no concurrent calls
- */
-int LpelBufferCount(buffer_t *buf) {
-	return buf->count;
-}

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -13,5 +13,4 @@ void *LpelBufferTop(buffer_t *buf);
 void  LpelBufferPop(buffer_t *buf);
 int   LpelBufferIsSpace(buffer_t *buf);
 void  LpelBufferPut(buffer_t *buf, void *item);
-int	  LpelBufferCount(buffer_t *buf);
 #endif /* _BUFFER_H_ */

--- a/src/include/stream.h
+++ b/src/include/stream.h
@@ -60,12 +60,17 @@ struct lpel_stream_t {
   atomic_int e_sem;           /** counter for empty space in the stream */
   void *usr_data;           /** arbitrary user data */
 
+  /* used for lpel hrc */
+  PRODLOCK_TYPE sd_lock;		/** to support update prod_sd, cons_sd */
+
   int is_entry;		/* if stream is an entry stream, used to support source/sink */
   int is_exit;			/* if stream is an exit stream, used to support source/sink */
 };
 
 
 int LpelStreamFillLevel(lpel_stream_t *s);
+
+/* so far only for lpel hrc */
 lpel_task_t *LpelStreamConsumer(lpel_stream_t *s);
 lpel_task_t *LpelStreamProducer(lpel_stream_t *s);
 


### PR DESCRIPTION
- use new lock (instead of reusing prod_lock) to support update prod_sd/cons_sd. This is to separate lock usages: one for polling (prod_lock) and one for update stream descriptor (sd_lock).
  - fix bug: trivial, LpelStreamConsumer/Producer should check if stream
    is null
