### PR TITLE
modify strategies to keep track task neighbourship

### DIFF
--- a/src/buffer/bounded.c
+++ b/src/buffer/bounded.c
@@ -145,5 +145,8 @@ void LpelBufferPut( buffer_t *buf, void *item)
 }
 
 
+int LpelBufferIsEmpty(buffer_t *buf) {
+	return (buf->data[buf->pread] == NULL);
+}
 
 

--- a/src/buffer/unbounded_ll.c
+++ b/src/buffer/unbounded_ll.c
@@ -135,4 +135,6 @@ void LpelBufferPut( buffer_t *buf, void *item)
   buf->tail = buf->tail->next;
 }
 
-
+int LpelBufferIsEmpty(buffer_t *buf) {
+	return (buf->head->next == NULL);
+}

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -13,4 +13,5 @@ void *LpelBufferTop(buffer_t *buf);
 void  LpelBufferPop(buffer_t *buf);
 int   LpelBufferIsSpace(buffer_t *buf);
 void  LpelBufferPut(buffer_t *buf, void *item);
+int LpelBufferIsEmpty(buffer_t *buf);
 #endif /* _BUFFER_H_ */

--- a/src/include/stream.h
+++ b/src/include/stream.h
@@ -64,6 +64,7 @@ struct lpel_stream_t {
 
   /* used for lpel hrc to keep update the neighbors*/
   stream_sched_info_t *sched_info;
+  struct lpel_stream_t *next;		/** for organizing in the free stream list, currently used only in hrc */
 };
 
 

--- a/src/sched/common/stream.c
+++ b/src/sched/common/stream.c
@@ -249,6 +249,8 @@ int LpelStreamGetId(lpel_stream_desc_t *sd) {
  * 	To get the accurate, one can introduce a new atomic counter and update when the stream is acctually written/read
  */
 int LpelStreamFillLevel(lpel_stream_t *s) {
+	if (s == NULL)
+		return 0;
 	int n = atomic_load(&s->n_sem);
 	if (n < 0)
 		return 0;

--- a/src/sched/hierarchy/hrc_stream.c
+++ b/src/sched/hierarchy/hrc_stream.c
@@ -11,7 +11,7 @@
 #include "buffer.h"
 #include "task.h"
 #include "hrc_task.h"
-
+#include "hrc_worker.h"
 #include "stream.h"
 #include "hrc_stream.h"
 #include "lpel/monitor.h"
@@ -32,10 +32,12 @@ lpel_stream_t *LpelStreamCreate(int size)
   if (0==size) size = STREAM_BUFFER_SIZE;
 
   /* allocate memory for both the stream struct and the buffer area */
-  lpel_stream_t *s = (lpel_stream_t *) malloc( sizeof(lpel_stream_t) );
-
-  /* reset buffer (including buffer area) */
-  s->buffer = LpelBufferInit( size);
+  lpel_stream_t *s = LpelWorkerGetStream();
+  if (!s) {
+  	s = (lpel_stream_t *) malloc( sizeof(lpel_stream_t) );
+  	s->buffer = LpelBufferInit( size);
+  	s->sched_info = (stream_sched_info_t *) malloc(sizeof(stream_sched_info_t));
+  }
 
   s->uid = atomic_fetch_add( &stream_seq, 1);
   PRODLOCK_INIT( &s->prod_lock );
@@ -45,13 +47,9 @@ lpel_stream_t *LpelStreamCreate(int size)
   s->prod_sd = NULL;
   s->cons_sd = NULL;
   s->usr_data = NULL;
-  s->sched_info = (stream_sched_info_t *) malloc(sizeof(stream_sched_info_t));
   s->sched_info->is_entry = 0;
   s->sched_info->is_exit = 0;
-  s->sched_info->ref_count = 0;
-  s->sched_info->destroy = 0;
-  PRODLOCK_INIT( &s->sched_info->sd_lock);
-
+  s->next = NULL;
   return s;
 }
 
@@ -250,46 +248,20 @@ void LpelStreamClose( lpel_stream_desc_t *sd, int destroy_s)
   }
 #endif
 
-  stream_sched_info_t *hrc;
-  int flag = 0;
-  if (destroy_s == 0) {
-  	if (sd->stream != NULL) {
-  		hrc = sd->stream->sched_info;
-  		PRODLOCK_LOCK(&hrc->sd_lock);
-  		hrc->ref_count--;
-  		if (hrc->ref_count == 0 && hrc->destroy == 1)
-  			flag = 1;
-  		else if (sd->mode == 'r' && sd->stream->cons_sd == sd)	// stream is not replaced yet or will not be replaced
-    		sd->stream->cons_sd = NULL;
-  		else if (sd->mode == 'w' && sd->stream->prod_sd == sd) 	// stream is not replaced yet or will not be replaced
-    		sd->stream->prod_sd = NULL;
-
-  		PRODLOCK_UNLOCK(&hrc->sd_lock);
-  	}
-  	if (flag)
-  		LpelStreamDestroy(sd->stream);
-
-  } else {		// snet-rts notifies to destroy stream
-  	assert(sd->stream != NULL);
-  	hrc = sd->stream->sched_info;
-  	PRODLOCK_LOCK(&hrc->sd_lock);
-  	hrc->ref_count--;
-  	hrc->destroy = 1;
-  	if (hrc->ref_count == 0)
-  		flag = 1;
-  	else if (sd->mode == 'r')
-  		sd->stream->cons_sd = NULL;
-  	else if (sd->mode == 'w')
-  		sd->stream->prod_sd = NULL;
-
-  	PRODLOCK_UNLOCK(&hrc->sd_lock);
-
-  	if (flag)
-  		LpelStreamDestroy(sd->stream);
+  workerctx_t *wc = sd->task->worker_context;
+  if (destroy_s) {
+  	assert(sd->mode == 'r');
+  	lpel_stream_t *s = sd->stream;
+  	assert(LpelBufferIsEmpty(s->buffer));
+  	s->prod_sd->stream = NULL;
+  	s->prod_sd = NULL;
+  	s->cons_sd = NULL;
+    LpelWorkerPutStream(wc, sd->stream);
+    sd->stream = NULL;
   }
-
   LpelTaskRemoveStream(sd->task, sd, sd->mode);
-  free(sd);
+  sd->task = NULL;
+  LpelWorkerPutSd(wc, sd);
 }
 
 
@@ -309,26 +281,21 @@ void LpelStreamReplace( lpel_stream_desc_t *sd, lpel_stream_t *snew)
   snew->sched_info->is_entry = sd->stream->sched_info->is_entry; /* technically, no need to set as entry stream shouldn't be replaced
     																				however it is set here for special case in source/sink mode */
 
-  /* destroy old stream */
-  int flag = 0;
-  PRODLOCK_LOCK(&sd->stream->sched_info->sd_lock);
-  sd->stream->sched_info->destroy = 1;
-  sd->stream->sched_info->ref_count--;
- 	if (sd->stream->sched_info->ref_count == 0)
- 		flag = 1;
- 	PRODLOCK_UNLOCK(&sd->stream->sched_info->sd_lock);
- 	if (flag)
- 		LpelStreamDestroy( sd->stream);
+  /* free the old stream */
+  workerctx_t *wc = sd->task->worker_context;
+  lpel_stream_t *s = sd->stream;
+  s->prod_sd->stream = NULL;
+  s->prod_sd = NULL;
+  s->cons_sd = NULL;
+  LpelWorkerPutStream(wc, sd->stream);
 
 
   /* assign new stream */
+  lpel_stream_desc_t *old_cons = snew->cons_sd;
+  old_cons->stream = NULL;
+  snew->cons_sd = sd;
   sd->stream = snew;
 
-  /* new consumer sd of stream */
-  PRODLOCK_LOCK( &sd->stream->sched_info->sd_lock);
-  sd->stream->cons_sd = sd;
-  sd->stream->sched_info->ref_count++;
-  PRODLOCK_UNLOCK( &sd->stream->sched_info->sd_lock);
 
   /* MONITORING CALLBACK */
 #ifdef USE_TASK_EVENT_LOGGING
@@ -355,7 +322,9 @@ lpel_stream_desc_t *LpelStreamOpen( lpel_stream_t *s, char mode)
   lpel_task_t *ct = LpelTaskSelf();
 
   assert( mode == 'r' || mode == 'w' );
-  sd = (lpel_stream_desc_t *) malloc( sizeof( lpel_stream_desc_t));
+  sd = LpelWorkerGetSd(ct->worker_context);
+  if (sd == NULL)
+  	sd = (lpel_stream_desc_t *) malloc( sizeof( lpel_stream_desc_t));
   sd->task = ct;
   sd->stream = s;
   sd->mode = mode;
@@ -374,9 +343,6 @@ lpel_stream_desc_t *LpelStreamOpen( lpel_stream_t *s, char mode)
   sd->mon = NULL;
 #endif
 
-  /*
-   * the first time set cons_sd/prod_sd, no need to use lock
-   */
   switch(mode) {
     case 'r': s->cons_sd = sd; break;
     case 'w': s->prod_sd = sd; break;
@@ -393,10 +359,6 @@ lpel_stream_desc_t *LpelStreamOpen( lpel_stream_t *s, char mode)
   	s->sched_info->is_exit = 1;
   if (LpelTaskIsWrapper(ct) && (mode == 'w'))
     	s->sched_info->is_entry = 1;
-
-  PRODLOCK_LOCK(&s->sched_info->sd_lock);
-  s->sched_info->ref_count++;
-  PRODLOCK_UNLOCK(&s->sched_info->sd_lock);
   return sd;
 }
 
@@ -407,14 +369,9 @@ lpel_stream_desc_t *LpelStreamOpen( lpel_stream_t *s, char mode)
 lpel_task_t *LpelStreamConsumer(lpel_stream_t *s) {
 	if (!s)
 		return NULL;
-	lpel_task_t *t;
-	PRODLOCK_LOCK( &s->sched_info->sd_lock);
-	if (s->cons_sd != NULL)
-		t = s->cons_sd->task;
-	else
-		t = NULL;
-	PRODLOCK_UNLOCK( &s->sched_info->sd_lock);
-	return t;
+	if (!s->cons_sd)
+		return NULL;
+	return s->cons_sd->task;
 }
 
 /*
@@ -423,17 +380,10 @@ lpel_task_t *LpelStreamConsumer(lpel_stream_t *s) {
 lpel_task_t *LpelStreamProducer(lpel_stream_t *s) {
 	if (!s)
 		return NULL;
-
-	lpel_task_t *t;
-	PRODLOCK_LOCK( &s->sched_info->sd_lock);
-	if (s->prod_sd != NULL)
-		t = s->prod_sd->task;
-	else
-		t = NULL;
-	PRODLOCK_UNLOCK( &s->sched_info->sd_lock);
-	return t;
+	if (!s->prod_sd)
+		return NULL;
+	return s->prod_sd->task;
 }
-
 
 /**
  * Destroy a stream
@@ -450,18 +400,13 @@ void LpelStreamDestroy( lpel_stream_t *s)
   atomic_destroy( &s->n_sem);
   atomic_destroy( &s->e_sem);
   LpelBufferCleanup( s->buffer);
-
-  assert(s->sched_info->ref_count == 0 && s->sched_info->destroy == 1);
-  PRODLOCK_DESTROY(&s->sched_info->sd_lock);
   free(s->sched_info);
   free( s);
 }
 
-
 int LpelStreamIsEntry(lpel_stream_t *s) {
 	return s->sched_info->is_entry;
 }
-
 int LpelStreamIsExit(lpel_stream_t *s) {
 	return s->sched_info->is_exit;
 }

--- a/src/sched/hierarchy/hrc_stream.h
+++ b/src/sched/hierarchy/hrc_stream.h
@@ -11,15 +11,10 @@
 struct stream_sched_info_t {
 	int is_entry;							/* if stream is an entry stream, i.e. written by source */
 	int is_exit;							/* if stream is an exit stream, i.e. read by sink */
-	int destroy;							/* if snet-rts level notify to destroy the stream */
-	int ref_count;						/* reference counter = number of stream_descriptors still linking to the stream
-															stream is destroyed when it is notified from snet-rts and the ref_count = 0 */
-	PRODLOCK_TYPE sd_lock;		/* lock to update ref_count, destroy and stream_descriptors */
-	};
+};
 
 lpel_task_t *LpelStreamProducer(lpel_stream_t *s);
 lpel_task_t *LpelStreamConsumer(lpel_stream_t *s);
 int LpelStreamIsEntry(lpel_stream_t *s);
 int LpelStreamIsExit(lpel_stream_t *s);
-
 #endif /* HRC_STREAM_H */ 

--- a/src/sched/hierarchy/hrc_worker.c
+++ b/src/sched/hierarchy/hrc_worker.c
@@ -46,6 +46,7 @@ static pthread_key_t masterctx_key;
 #endif /* HAVE___THREAD */
 
 
+static void cleanupMasterMb();
 
 /**
  * Initialise worker globally
@@ -104,6 +105,8 @@ void LpelWorkersInit( int size) {
 
 	/* mailbox */
 	wc->mailbox = LpelMailboxCreate();
+	wc->free_sd = NULL;
+	wc->free_stream = NULL;
 	}
 }
 
@@ -126,6 +129,8 @@ void LpelWorkersCleanup( void) {
 	for( i=0; i<num_workers; i++) {
 		wc = WORKER_PTR(i);
 		LpelMailboxDestroy(wc->mailbox);
+		LpelWorkerDestroyStream(wc);
+		LpelWorkerDestroySd(wc);
 		free(wc);
 	}
 	/* free workers tables */
@@ -133,11 +138,7 @@ void LpelWorkersCleanup( void) {
 	free( waitworkers);
 
 	/* clean up master's mailbox */
-	workermsg_t msg;
-	while (LpelMailboxHasIncoming(MASTER_PTR->mailbox)) {
-		LpelMailboxRecv(MASTER_PTR->mailbox, &msg);
-		assert(msg.type == WORKER_MSG_REQUEST);
-	}
+	cleanupMasterMb();
 
 	LpelMailboxDestroy(master->mailbox);
 	LpelTaskqueueDestroy(master->ready_tasks);
@@ -172,8 +173,8 @@ void LpelWorkersSpawn( void) {
 void LpelWorkersTerminate(void) {
 	workermsg_t msg;
 	msg.type = WORKER_MSG_TERMINATE;
-	LpelMailboxSend(MASTER_PTR->mailbox, &msg);
 	LpelWorkerBroadcast(&msg);
+	LpelMailboxSend(MASTER_PTR->mailbox, &msg);
 }
 
 /**
@@ -194,6 +195,30 @@ void LpelWorkerRunTask( lpel_task_t *t) {
 
 
 /************************ Private functions ***********************************/
+/*
+ * clean up master's mailbox before terminating master
+ * last messages including: task request from worker, and return zombie task
+ */
+static void cleanupMasterMb() {
+	workermsg_t msg;
+	lpel_task_t *t;
+	while (LpelMailboxHasIncoming(MASTER_PTR->mailbox)) {
+		LpelMailboxRecv(MASTER_PTR->mailbox, &msg);
+		switch(msg.type) {
+		case WORKER_MSG_REQUEST:
+			break;
+		case WORKER_MSG_RETURN:
+			t = msg.body.task;
+			assert(t->state == TASK_ZOMBIE);
+			LpelTaskDestroy(t);
+			break;
+		default:
+			assert(0);
+			break;
+		}
+	}
+}
+
 static void returnTask( lpel_task_t *t) {
 	workermsg_t msg;
 	msg.type = WORKER_MSG_RETURN;
@@ -485,6 +510,8 @@ static void *WrapperThread( void *arg)
 	WrapperLoop( wp);
 
 	LpelMailboxDestroy(wp->mailbox);
+	LpelWorkerDestroyStream(wp);
+	LpelWorkerDestroySd(wp);
 	free( wp);
 
 #ifdef USE_MCTX_PCL
@@ -501,6 +528,8 @@ workerctx_t *LpelCreateWrapperContext(int wid) {
 	wp->current_task = NULL;
 	wp->current_task = NULL;
 	wp->mon = NULL;
+	wp->free_sd = NULL;
+	wp->free_stream = NULL;
 	//wp->marked_del = NULL;
 
 	/* mailbox */
@@ -696,4 +725,89 @@ void LpelWorkerDispatcher( lpel_task_t *t) {
 int LpelWorkerIsWrapper(workerctx_t *wc) {
 	assert(wc != NULL);
 	return (wc->wid < 0? 1 : 0);
+}
+
+
+
+/******************************************
+ * STREAM RELATED FUNCTIONS
+ ******************************************/
+void LpelWorkerPutStream(workerctx_t *wc, lpel_stream_t *s) {
+	if (wc->free_stream == NULL) {
+		wc->free_stream = s;
+		s->next = NULL;
+	} else {
+		s->next = wc->free_stream;
+		wc->free_stream = s;
+	}
+}
+
+lpel_stream_t *LpelWorkerGetStream() {
+	lpel_stream_t *t;
+	workerctx_t *wc = LpelWorkerSelf();
+	if (wc == NULL) {
+		return NULL;
+	}
+
+	t = wc->free_stream;
+	if (t) {
+		wc->free_stream = t->next;
+		t->next = NULL;
+		assert(t->cons_sd == NULL && t->prod_sd == NULL);
+	}
+	return t;
+}
+
+void LpelWorkerPutSd(workerctx_t *wc, lpel_stream_desc_t *sd) {
+	if (wc->free_sd == NULL) {
+		wc->free_sd = sd;
+		sd->next = NULL;
+	} else {
+		sd->next = wc->free_sd;
+		wc->free_sd = sd;
+	}
+}
+
+lpel_stream_desc_t *LpelWorkerGetSd(workerctx_t *wc) {
+	lpel_stream_desc_t *t = wc->free_sd;
+	if (t != NULL) {
+		if (t->task == NULL && t->stream == NULL) {
+			wc->free_sd = t->next;
+			t->next = NULL;
+			return t;
+		} else {
+			lpel_stream_desc_t *prev = t;
+			t = t->next;
+			while (t != NULL) {
+				if (t->task == NULL && t->stream == NULL) {
+					prev->next = t->next;
+					t->next = NULL;
+					return t;
+				}
+				prev = t;
+				t = t->next;
+			}
+		}
+	}
+	return NULL;
+}
+
+void LpelWorkerDestroyStream(workerctx_t *wc) {
+	lpel_stream_t *head = wc->free_stream;
+	lpel_stream_t *t;
+	while (head != NULL) {
+		t = head->next;
+		LpelStreamDestroy(head);
+		head = t;
+	}
+}
+
+void LpelWorkerDestroySd(workerctx_t *wc) {
+	lpel_stream_desc_t *head = wc->free_sd;
+	lpel_stream_desc_t *t;
+	while (head != NULL) {
+		t = head->next;
+		free(head);
+		head = t;
+	}
 }

--- a/src/sched/hierarchy/hrc_worker.h
+++ b/src/sched/hierarchy/hrc_worker.h
@@ -9,6 +9,7 @@
 #include "hrc_task.h"
 #include "mailbox.h"
 #include "taskqueue.h"
+#include "hrc_stream.h"
 
 //#define _USE_DBG__
 
@@ -36,6 +37,8 @@ struct workerctx_t {
   mon_worker_t *mon;
   mailbox_t    *mailbox;
   char          padding[64];
+  lpel_stream_t *free_stream;			/* list of free stream */
+  lpel_stream_desc_t *free_sd;		/* list of free stream desc */
 };
 
 
@@ -54,5 +57,18 @@ workerctx_t *LpelCreateWrapperContext(int wid);		// can be wrapper or source/sin
 void LpelWorkerTaskBlock(lpel_task_t *t);
 void LpelWorkerTaskWakeup( lpel_task_t *t);
 int LpelWorkerIsWrapper(workerctx_t *wc);
+
+
+/* put and get free stream */
+void LpelWorkerPutStream(workerctx_t *wc, lpel_stream_t *s);
+lpel_stream_t *LpelWorkerGetStream();
+
+/* put and get free stream desc*/
+void LpelWorkerPutSd(workerctx_t *wc, lpel_stream_desc_t *s);
+lpel_stream_desc_t *LpelWorkerGetSd(workerctx_t *wc);
+
+/* destroy list of free stream and stream desc when terminate worker */
+void LpelWorkerDestroyStream(workerctx_t *wc);
+void LpelWorkerDestroySd(workerctx_t *wc);
 
 #endif /* _HRC_WORKER_H_ */


### PR DESCRIPTION
- to keep track of neighbour-ship
  - no longer need the sd_lock from stream 
  - keep destroyed stream and desc in a free list: to reuse later and avoid accessing to freed memory
